### PR TITLE
Fix email, username errors and add enhancement (new configuration "fields")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,119 @@
 facebook-ion-auth
 =================
 
-facebook login working with ion_auth (codeigniter)
+Facebook login working with [CodeIgniter Ion Auth](http://benedmunds.com/ion_auth/)
 
+## Requirement
+
+- [CodeIgniter Ion Auth](http://benedmunds.com/ion_auth/)
+
+## Installation
+
+- Copy `config/facebook_ion_auth.php` to `application/config/facebook_ion_auth.php`.
+- Copy `libraries/Facebook_ion_auth.php` to `application/libraries/Facebook_ion_auth.php`.
+- Configure your Facebook API settings in `application/config/facebook_ion_auth.php` for
+    - `app_id` - Your app id
+    - `app_scret` - Your app secret key
+    - `scope` - custom permissions check - http://developers.facebook.com/docs/reference/login/#permissions
+    - `fields` - fields to retrieve from Facebook; if set to `''`, default is `id,first_name,last_name`; See https://developers.facebook.com/docs/graph-api/reference/user
+    - `redirect_uri` - url to redirect back from facebook. If set to `''`, `site_url('')` will be used
+
+## Example Usage
+
+Assuming that you have installed [CodeIgniter Ion Auth](http://benedmunds.com/ion_auth/), add this in `application/config/autoload.php`.
+
+    $autoload['libraries'] = array('ion_auth', 'Facebook_ion_auth');
+
+Create `application/core/MY_AuthController.php` and put this code into the file
+
+    <?php
+    if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+    /**
+     * AuthController
+     */
+    class MY_AuthController extends CI_Controller
+    {
+        public function __construct()
+        {
+            parent::__construct();
+
+            $this->load->config('ion_auth', true);
+
+            if (uri_string() != 'auth/login') {
+                $this->_is_login();
+            }
+        }
+
+        private function _is_login()
+        {
+            if (!$this->ion_auth->logged_in()) {
+                redirect('auth/login');
+            }
+        }
+    }
+
+To auto-load all files in `application/core/`, add this code in `application/config/config.php`.
+
+    /**
+    | -------------------------------------------------------------------
+    |  Native Auto-load
+    | -------------------------------------------------------------------
+    |
+    | Nothing to do with config/autoload.php, this allows PHP autoload to work
+    | for base controllers and some third-party libraries.
+    |
+    */
+    function __autoload($class)
+    {
+        if(strpos($class, 'CI_') !== 0) {
+            require(APPPATH . 'core/'. $class . '.php');
+        }
+    }
+
+Extends the default controller `application/controllers/Welcome.php` to `MY_AuthController.php` for authentication check.
+
+    class Welcome extends MY_AuthController {
+        // ....
+    }
+
+Create a new controller file `application/controllers/Facebook_login.php` with the following code:
+
+    <?php
+    defined('BASEPATH') OR exit('No direct script access allowed');
+
+    class Facebook_login extends CI_Controller
+    {
+        /**
+         * Index Page for this controller.
+         * You will be redirected to the facebook login page
+         */
+        function index()
+        {
+            $this->facebook_ion_auth->login();
+        }
+
+        /**
+         * Controller that is redirected back from facebook after login
+         */
+        public function action()
+        {
+            $code = $this->input->get('code');
+            if ($code) {
+                $this->facebook_ion_auth->login();
+                redirect('/');
+            } else {
+                redirect('auth/login');
+            }
+        }
+    }
+
+In `application/views/auth/login.php`, add "Login with Facebook" button using the Facebook_login controller created above.
+
+    <a href="<?php echo site_url('facebook_login'); ?>">Login with Facebook</a>
+
+Update `application/config/facebook_ion_auth.php` for `redirect_uri`.
+
+    $config['redirect_uri'] = site_url('facebook_login/action'); // url to redirect back from facebook.
+
+Then, when you access your application in the browser, you will see the login form with facebook login button.

--- a/config/facebook_ion_auth.php
+++ b/config/facebook_ion_auth.php
@@ -7,5 +7,5 @@
 $config['app_id']       = '';       // Your app id
 $config['app_secret']   = '';       // Your app secret key
 $config['scope']        = 'email';  // custom permissions check - http://developers.facebook.com/docs/reference/login/#permissions
-$config['fields']       = '';       // fields to retrieve; if set to '', default is "id,first_name,last_name"
+$config['fields']       = 'id,first_name,last_name,email'; // fields to retrieve; if set to '', default is "id,first_name,last_name"
 $config['redirect_uri'] = '';       // url to redirect back from facebook. If set to '', site_url('') will be used

--- a/config/facebook_ion_auth.php
+++ b/config/facebook_ion_auth.php
@@ -4,8 +4,8 @@
 | Settings.
 | -------------------------------------------------------------------------
 */
-$config['app_id'] 		= ''; 		// Your app id
-$config['app_secret'] 	= ''; 		// Your app secret key
-$config['scope'] 		= 'email'; 	// custom permissions check - http://developers.facebook.com/docs/reference/login/#permissions
-$config['fields']		= ''; 		// fields to retrieve; if set to '', default is "id,first_name,last_name"
-$config['redirect_uri'] = ''; 		// url to redirect back from facebook. If set to '', site_url('') will be used
+$config['app_id']       = '';       // Your app id
+$config['app_secret']   = '';       // Your app secret key
+$config['scope']        = 'email';  // custom permissions check - http://developers.facebook.com/docs/reference/login/#permissions
+$config['fields']       = '';       // fields to retrieve; if set to '', default is "id,first_name,last_name"
+$config['redirect_uri'] = '';       // url to redirect back from facebook. If set to '', site_url('') will be used

--- a/config/facebook_ion_auth.php
+++ b/config/facebook_ion_auth.php
@@ -7,4 +7,5 @@
 $config['app_id'] 		= ''; 		// Your app id
 $config['app_secret'] 	= ''; 		// Your app secret key
 $config['scope'] 		= 'email'; 	// custom permissions check - http://developers.facebook.com/docs/reference/login/#permissions
+$config['fields']		= ''; 		// fields to retrieve; if set to '', default is "id,first_name,last_name"
 $config['redirect_uri'] = ''; 		// url to redirect back from facebook. If set to '', site_url('') will be used

--- a/libraries/Facebook_ion_auth.php
+++ b/libraries/Facebook_ion_auth.php
@@ -1,9 +1,9 @@
-<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed'); 
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 class Facebook_ion_auth {
 
 	/*
-		Library for login with facebook and create a ion_auth compatibility session. 
+		Library for login with facebook and create a ion_auth compatibility session.
 
 		author: Daniel Georgiev
 		website: http://dgeorgiev.biz
@@ -12,13 +12,13 @@ class Facebook_ion_auth {
 	public function __construct() {
 
 		// get Codeigniter instance
-	    $this->CI =& get_instance();
+		$this->CI =& get_instance();
 
-	    // Load config
-	    $this->CI->load->config('facebook_ion_auth', TRUE);
+		// Load config
+		$this->CI->load->config('facebook_ion_auth', TRUE);
 
 		$this->app_id = $this->CI->config->item('app_id', 'facebook_ion_auth');
-		$this->app_secret = $this->CI->config->item('app_secret', 'facebook_ion_auth'); 
+		$this->app_secret = $this->CI->config->item('app_secret', 'facebook_ion_auth');
 		$this->scope = $this->CI->config->item('scope', 'facebook_ion_auth');
 
 		$this->fields = $this->CI->config->item('fields', 'facebook_ion_auth');
@@ -29,47 +29,43 @@ class Facebook_ion_auth {
 		$this->dummy_password = 'facebookdoesnothavepass123^&*%';
 
 		if($this->CI->config->item('redirect_uri', 'facebook_ion_auth') === '' ) {
-			$this->my_url = site_url(''); 
+			$this->my_url = site_url('');
 		} else {
 			$this->my_url = $this->CI->config->item('redirect_uri', 'facebook_ion_auth');
 		}
-		
+
 	}
 
-    public function login() {
+	public function login() {
 
-    	// null at first
+		// null at first
 		$code = $this->CI->input->get('code');
-		
+
 		// if is not set go make a facebook connection
 		if(!$code) {
 
 			// create a unique state
-	   		$this->CI->session->set_userdata('state', md5(uniqid(rand(), TRUE)));
+			$this->CI->session->set_userdata('state', md5(uniqid(rand(), TRUE)));
 
-	   		// redirect to facebook oauth page
-	   		$url_to_redirect =  "https://www.facebook.com/dialog/oauth?client_id=" 
-	       						.$this->app_id
-	       						."&redirect_uri=".urlencode($this->my_url)
-	       						."&state=".$this->CI->session->userdata('state').'&scope='.$this->scope;
+			// redirect to facebook oauth page
+			$url_to_redirect = "https://www.facebook.com/dialog/oauth?client_id="
+									.$this->app_id
+									."&redirect_uri=".urlencode($this->my_url)
+									."&state=".$this->CI->session->userdata('state').'&scope='.$this->scope;
 
-	       	redirect($url_to_redirect);
+			redirect($url_to_redirect);
 
-	   	} else {
-
-	   		// check if session state is equal to the returned state
-
+		} else {
+			// check if session state is equal to the returned state
 			if($this->CI->session->userdata('state') && ($this->CI->session->userdata('state') === $this->CI->input->get('state'))) {
 
-
 				$token_url = "https://graph.facebook.com/oauth/access_token?"
-			       . "client_id=" . $this->app_id . "&redirect_uri=" . urlencode($this->my_url)
-			       . "&client_secret=" . $this->app_secret . "&code=" . $code;
+					. "client_id=" . $this->app_id . "&redirect_uri=" . urlencode($this->my_url)
+					. "&client_secret=" . $this->app_secret . "&code=" . $code;
 
 				$response = file_get_contents($token_url);
-				
-				$params = null;
 
+				$params = null;
 				parse_str($response, $params);
 
 				$this->CI->session->set_userdata('access_token', $params['access_token']);
@@ -97,12 +93,11 @@ class Facebook_ion_auth {
 				}
 
 				return true;
-		    }
-		    else {
-		   		return false;
-		    }
-	    }
-    }
+			} else {
+				return false;
+			}
+		}
+	}
 }
 
 /* End of file Facebook_ion_auth.php */

--- a/libraries/Facebook_ion_auth.php
+++ b/libraries/Facebook_ion_auth.php
@@ -26,6 +26,8 @@ class Facebook_ion_auth {
 			$this->fields = 'id,first_name,last_name';
 		}
 
+		$this->dummy_password = 'facebookdoesnothavepass123^&*%';
+
 		if($this->CI->config->item('redirect_uri', 'facebook_ion_auth') === '' ) {
 			$this->my_url = site_url(''); 
 		} else {
@@ -83,7 +85,7 @@ class Facebook_ion_auth {
 					// check if this user is already registered
 					if(!$this->CI->ion_auth_model->identity_check($user->email)){
 						$username = 'user'.$user->id; // generate username with facebook id
-						$register = $this->CI->ion_auth->register($username, 'facebookdoesnothavepass123^&*%', $user->email, array(
+						$register = $this->CI->ion_auth->register($username, $this->dummy_password, $user->email, array(
 							'first_name'  => $user->first_name,
 							'last_name'   => $user->last_name,
 							// if you want to add more facebook-related fields, you will have to add them in the user table
@@ -91,7 +93,7 @@ class Facebook_ion_auth {
 							//'fb_info'     => serialize($user),
 						));
 					}
-					$login = $this->CI->ion_auth->login($user->email, 'facebookdoesnothavepass123^&*%', 1);
+					$login = $this->CI->ion_auth->login($user->email, $this->dummy_password, 1);
 				}
 
 				return true;


### PR DESCRIPTION
It is a great Facebook login module, but it needs a few improvements:
- A new configuration `$config['fields']` is added because `graph.facebook.com/me` API is only returning `id,name` unless we provides `fields`  in API call. We should provide `email` in `$config['fields']`.
- Fix error for `$user->username` because `username` is not returned from graph API
- Check if `email` is received from API result as user can deny email permission. Unless `email` is received, we can't proceed.
- Receiving `first_name` and `last_name` returning from API, no need to explode `name` for `first_name` and `last_name`.
- Always login after user registration even upon the very first time.
- Store dummy password `facebookdoesnothavepass123^&*%` in a class variable to avoid reduntant usage.
